### PR TITLE
Add compatibility with Rails 7

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -2,7 +2,12 @@ module WCC
   module RakeHelpers
 
     def self.db_config
-      db_config_file_data[ENV['RAILS_ENV'] || 'development'] || {}
+      if Rails::VERSION::MAJOR == 7
+        configs = db_config_file_data.configs_for(env_name: ENV['RAILS_ENV'] || 'development')
+        configs.any? ? configs[0].configuration_hash : {}
+      else
+        db_config_file_data[ENV['RAILS_ENV'] || 'development'] || {}
+      end
     end
 
     def self.db_cmd_with_password(cmd, pw)

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -2,7 +2,7 @@ module WCC
   module RakeHelpers
 
     def self.db_config
-      if Rails::VERSION::MAJOR == 7
+      if Rails::VERSION::MAJOR >= 7
         configs = db_config_file_data.configs_for(env_name: ENV['RAILS_ENV'] || 'development')
         configs.any? ? configs[0].configuration_hash : {}
       else


### PR DESCRIPTION
This PR makes wcc-base compatible with Rails 7 by fixing this deprecation:

```
DEPRECATION WARNING: [] is deprecated and will be removed from Rails 6.2 (Use configs_for) (called from db_config at .../wcc/lib/tasks/db.rake:6)
```

This is shown when running DB-related rake tasks like `db:create`.

The change is actually compatible with Rails 6.2 but since this gem seems to be use by different apps I'm making the game apply starting on Rails 7.

`configs_for` returns an array of configurations since new Rails versions can have multiple database connections so we have to handle that too.